### PR TITLE
ci: npmパッケージの依存関係を年1回のスケジュールで更新するように設定を追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "yearly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
     schedule:
       interval: "monthly"
 
+  # The npm dependencies are updated yearly instead of monthly to reduce noise from frequent updates.
   - package-ecosystem: "npm"
     directory: "/"
     schedule:


### PR DESCRIPTION
This pull request makes a minor update to the Dependabot configuration by adding a yearly schedule for npm package updates.